### PR TITLE
readme: must use "-v"

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,13 @@
 of the test suite:
 
 ```txt
-$ go test
+$ go test -v
 PASS
 Tests: 460, Assertions: 1319, Time: 18.600047ms
 ok      github.com/elliotchance/testify-stats   0.014s
 ```
+
+**Note:** The statistics will only print with the `-v` option. This is because the testing package will capture all stdout and only print it under verbose more, or if there was a failure. I couldn't find a way around this. If you know of one, please let me know.
 
 # How to Use It
 


### PR DESCRIPTION
The statistics will only print with the `-v` option. This is because the testing package will capture all stdout and only print it under verbose more, or if there was a failure. I couldn't find a way around this. If you know of one, please let me know.